### PR TITLE
Ping owner of the reminder in the channel

### DIFF
--- a/src/handlers/reminderHandler.js
+++ b/src/handlers/reminderHandler.js
@@ -16,7 +16,7 @@ module.exports = async (Bot) => {
                 try {
                     if (r.channelID && Bot.client.channels.get(r.channelID)) {
                         try {
-                            Bot.client.channels.get(r.channelID).send({ embed });
+                            Bot.client.channels.get(r.channelID).send(`<@${r.owner}>`, { embed });
                         } catch (err) {
                             if (err.message.includes('Missing Access')) {
                                 try {


### PR DESCRIPTION
**What I did**
This PR contains a single-line change that will insert a mention into the message content alongside the embed. 

**Why I did it**
If the reminder is set to be posted to a server channel, the person who created the reminder should be pinged.

**How I did it**
(I'm not really sure what I'd put here exactly, as the changes can be seen within the PR)

This allows:
1) The person to view their mention history and refer back to the reminder whenever (providing the message doesn't get deleted by anyone)
2) The message to not be posted and missed if the chat is extremely active